### PR TITLE
Handle Port Authority as NYC

### DIFF
--- a/nyc_commuter_homes.py
+++ b/nyc_commuter_homes.py
@@ -87,7 +87,8 @@ def search_properties_near_stop(stop_data: pd.Series, search_radius_miles: float
     elif 'JOURNAL SQUARE' in stop_name.upper():
         search_location = "Jersey City, NJ"
     elif 'PORT AUTHORITY' in stop_name.upper():
-        search_location = "Weehawken, NJ"  # Close to Port Authority
+        # Port Authority Bus Terminal is in Manhattan
+        search_location = "New York, NY"
     else:
         # For other stops, try to infer from coordinates
         if stop_lat > 40.7 and stop_lon > -74.1:

--- a/nyc_commuter_homes_comprehensive.py
+++ b/nyc_commuter_homes_comprehensive.py
@@ -95,7 +95,8 @@ def infer_search_location(stop_data: pd.Series) -> str:
     elif 'JOURNAL SQUARE' in stop_name:
         return "Jersey City, NJ"
     elif 'PORT AUTHORITY' in stop_name:
-        return "Weehawken, NJ"
+        # Search near the Port Authority Bus Terminal in Manhattan
+        return "New York, NY"
     elif 'JERSEY CITY' in stop_name:
         return "Jersey City, NJ"
     elif 'WEEHAWKEN' in stop_name:

--- a/test_search_location.py
+++ b/test_search_location.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from unittest.mock import patch
+import nyc_commuter_homes
+import nyc_commuter_homes_comprehensive
+
+
+def test_search_location_port_authority_nyc_commuter_homes():
+    stop = pd.Series({
+        "stop_name": "Port Authority Bus Terminal",
+        "stop_lat": 40.757,
+        "stop_lon": -73.990,
+        "source": "bus"
+    })
+    with patch('nyc_commuter_homes.scrape_property') as mock_scrape:
+        mock_scrape.return_value = pd.DataFrame()
+        nyc_commuter_homes.search_properties_near_stop(stop)
+        assert mock_scrape.call_args[1]['location'] == "New York, NY"
+
+
+def test_infer_search_location_port_authority_comprehensive():
+    stop = pd.Series({
+        "stop_name": "Port Authority Bus Terminal",
+        "stop_lat": 40.757,
+        "stop_lon": -73.990,
+        "source": "bus"
+    })
+    result = nyc_commuter_homes_comprehensive.infer_search_location(stop)
+    assert result == "New York, NY"


### PR DESCRIPTION
## Summary
- adjust search location handling around Port Authority bus terminal
- ensure comprehensive search also returns `New York, NY`
- add regression tests

## Testing
- `pytest -q`